### PR TITLE
remove byebug 💥

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,5 +53,3 @@ end
 
 # Use debugger
 # gem 'debugger', group: [:development, :test]
-
-gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,8 +50,6 @@ GEM
     addressable (2.3.8)
     arel (6.0.3)
     builder (3.2.2)
-    byebug (5.0.0)
-      columnize (= 0.9.0)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
@@ -59,7 +57,6 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.9.1.1)
-    columnize (0.9.0)
     diff-lcs (1.2.5)
     dotenv (2.0.2)
     email_spec (1.6.0)
@@ -191,7 +188,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  byebug
   coffee-rails (~> 4.0.0)
   dotenv
   email_spec


### PR DESCRIPTION
@etagwerker @mauro-oto this removes byebug due to travis build errors for ruby 1.9.3. check it out