### PR TITLE
Re-added byebug, made it require: false, removed from spec_helper.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ group :production do
 end
 
 group :development do
-  gem 'pry-byebug', platform: [:ruby_20]
+  gem 'pry-byebug', platform: [:ruby_20], require: false
   gem 'sqlite3'
   gem 'spring'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ group :production do
 end
 
 group :development do
-  gem 'byebug', require: false
+  gem 'pry-byebug', platform: [:ruby_20]
   gem 'sqlite3'
   gem 'spring'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,6 @@ source 'https://rubygems.org'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 4.2.5.1'
 # Use sqlite3 as the database for Active Record
-group :development do
-  gem 'sqlite3'
-end
 
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 4.0.3'
@@ -30,9 +27,6 @@ gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 0.4.0',          group: :doc
 
-# Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
-gem 'spring',        group: :development
-
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 
@@ -40,11 +34,18 @@ group :production do
   gem 'pg'
 end
 
+group :development do
+  gem 'byebug', require: false
+  gem 'sqlite3'
+  gem 'spring'
+end
+
 group :test do
   gem 'rspec-rails'
   gem 'email_spec'
   gem 'factory_girl_rails'
 end
+
 # Use unicorn as the app server
 # gem 'unicorn'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,7 @@ GEM
     addressable (2.3.8)
     arel (6.0.3)
     builder (3.2.2)
+    byebug (8.2.1)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
@@ -188,6 +189,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  byebug
   coffee-rails (~> 4.0.0)
   dotenv
   email_spec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,7 @@ GEM
     arel (6.0.3)
     builder (3.2.2)
     byebug (8.2.1)
+    coderay (1.1.0)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
@@ -93,6 +94,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
+    method_source (0.8.2)
     mime-types (2.99)
     mini_portile2 (2.0.0)
     minitest (5.8.4)
@@ -102,6 +104,13 @@ GEM
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
     pg (0.18.2)
+    pry (0.10.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-byebug (3.3.0)
+      byebug (~> 8.0)
+      pry (~> 0.10)
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -158,6 +167,7 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    slop (3.6.0)
     spring (1.3.6)
     sprockets (2.12.4)
       hike (~> 1.2)
@@ -189,7 +199,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  byebug
   coffee-rails (~> 4.0.0)
   dotenv
   email_spec
@@ -198,6 +207,7 @@ DEPENDENCIES
   jquery-rails
   letsfreckle-client!
   pg
+  pry-byebug
   rails (~> 4.2.5.1)
   rspec-rails
   sass-rails (~> 4.0.3)

--- a/lib/tasks/importer.rake
+++ b/lib/tasks/importer.rake
@@ -1,5 +1,3 @@
-require 'byebug'
-
 namespace :import do
 
   task users: :environment do
@@ -45,7 +43,7 @@ namespace :calc do
   task leaderboards: :environment do
     start_date = Time.now.beginning_of_week.to_date
     end_date = Time.now.end_of_week.to_date
-    
+
     Project.all.each do |project|
       project_leaderboard = ProjectLeaderboard.find_or_create_by(project_id: project.id,
                                                                  start_date: start_date,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,6 @@
 # files.
 
 require "email_spec"
-require "byebug"
 
 # Given that it is always loaded, you are encouraged to keep this file as
 # light-weight as possible. Requiring heavyweight dependencies from this file


### PR DESCRIPTION
Hey @etagwerker, @schmierkov, 

This PR adds `byebug` back in, makes it `require: false`, and removes it from `spec_helper`, you'll need to require it to use it. 

Please check it out, thanks! 